### PR TITLE
Update __init__.py

### DIFF
--- a/truths/__init__.py
+++ b/truths/__init__.py
@@ -15,4 +15,4 @@
 #   limitations under the License.
 #
 
-from truths import Truths
+from truths.truths import Truths


### PR DESCRIPTION
for Python version above 3.0
To avoid the below Error. 
ImportError: cannot import name 'Truths' from 'truths'