### PR TITLE
Add feature `save_csv`

### DIFF
--- a/truths/truths.py
+++ b/truths/truths.py
@@ -18,6 +18,7 @@
 import itertools
 from prettytable import PrettyTable
 import re
+import csv
 
 
 class Gob(object):
@@ -59,6 +60,13 @@ class Truths(object):
             return [int(item) for item in row]
         else:
             return row
+    
+    def save_csv(self, file_name='truths.csv'):
+        with open(file_name, mode='w') as f:
+            writer = csv.writer(f, delimiter=',', quotechar='"', quoting=csv.QUOTE_MINIMAL)
+            writer.writerow(self.base + self.phrases)
+            for conditions_set in self.base_conditions:
+                writer.writerow(self.calculate(*conditions_set))
 
     def __str__(self):
         t = PrettyTable(self.base + self.phrases)


### PR DESCRIPTION
The original code only supports the printing of the truth table.
I have added a `save_csv` function to add export functionality.

Besides, it would be nice if you also merge [pull request #4](https://github.com/tr3buchet/truths/pull/4) that make possible to use this code with python 3.

Thanks.