### PR TITLE
fixing circular logic in import

### DIFF
--- a/truths/__init__.py
+++ b/truths/__init__.py
@@ -15,4 +15,4 @@
 #   limitations under the License.
 #
 
-from truths import Truths
+from truths import *


### PR DESCRIPTION
The problem is that Truth is not defined for the most recent call when __init__.py is run. By asking module to import everything (*), we will have one call that will import none then returning to parent call that imports Truth